### PR TITLE
Enable ability to call repeatedly to allow caching in multiple streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function Cached(options) {
         toFile: toFile,
         fromFile: fromFile,
         changed: changed,
-        onexit: onexit
+        onfinish: onfinish
     };
 
     /**
@@ -71,7 +71,7 @@ function Cached(options) {
     /**
      * Save the cache file on exit.
      */
-    function onexit() {
+    function onfinish() {
         if(cached.changes) {
             try {
                 toFile(cached.options.cacheFile);
@@ -87,11 +87,6 @@ function Cached(options) {
     // Load the cache file if any, synchronously.
     if(fs.existsSync(cached.options.cacheFile))
         fromFile(cached.options.cacheFile);
-
-    // Save the cache on exits and ctrl+c
-    ["exit", "SIGINT"].forEach(function(event) {
-        process.on(event, onexit);
-    });
 
     // Return the stream function
     var plugin = function(options) {
@@ -151,6 +146,7 @@ function Cached(options) {
             });
         }, function(callback) {
             this.emit("cache-report", cacheHits);
+            onfinish();
             callback();
         });
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-cache-money",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A gulp caching system that saves to disk.",
   "main": "index.js",
   "directories": {

--- a/test/index.js
+++ b/test/index.js
@@ -8,18 +8,36 @@ var path = require("path"),
 const TEST_DIR = __dirname;
 const EXAMPLE_FILE = path.join(TEST_DIR, "example.txt");
 const CACHE_FILE = path.join(TEST_DIR, "cache.json");
+const CACHE_FILE_2 = path.join(TEST_DIR, "cache2.json");
 
 describe("Cached", function() {
+    var Cached = require("../");
     var cache, cached;
 
     describe("Configuration", function() {
         it("should correctly require configure cached", function() {
-            cache = require("../")({ cacheFile: CACHE_FILE });
+            cache = Cached({ cacheFile: CACHE_FILE });
             cached = cache.cached; // Extract reference to cached
 
             assert(cached.options);
-            assert(typeof cached === "function");
+            assert(typeof cached === "object");
             assert.equal(cached.options.cacheFile, CACHE_FILE);
+        });
+
+        it("should correctly configure two separate cached methods", function() {
+            cache1 = Cached({ cacheFile: CACHE_FILE });
+            cached1 = cache1.cached; // Extract reference to cached
+
+            cache2 = Cached({ cacheFile: CACHE_FILE_2 });
+            cached2 = cache2.cached; // Extract reference to cached
+
+            assert(cached1.options);
+            assert(typeof cached1 === "object");
+            assert.equal(cached1.options.cacheFile, CACHE_FILE);
+
+            assert(cached2.options);
+            assert(typeof cached2 === "object");
+            assert.equal(cached2.options.cacheFile, CACHE_FILE_2);
         });
     });
 
@@ -28,24 +46,24 @@ describe("Cached", function() {
             var options = { foo: "bar" },
                 defaults = { foo: "wuggles", bar: "foo" };
 
-            options = cached.defaults(options, defaults);
+            options = Cached.defaults(options, defaults);
 
             assert.equal(options.bar, "foo");
             assert.equal(options.foo, "bar");
         });
     });
 
-    describe(".md5", function() {
+    describe(".sha", function() {
 
         before(function(done) {
             fs.writeFile(EXAMPLE_FILE, "Hello World!\n", done);
         });
 
-        it("should md5 a stream and return the hash", function(done) {
-            cached.md5(fs.createReadStream(EXAMPLE_FILE), function(err, hash) {
+        it("should SHA a stream and return the hash", function(done) {
+            Cached.sha(fs.createReadStream(EXAMPLE_FILE), function(err, hash) {
                 if(err) return done(err);
 
-                assert.equal(hash, "8ddd8be4b179a529afa5f2ffae4b9858");
+                assert.equal(hash, "03ba204e50d126e4674c005e04d82e84c21366780af1f43bd54a37816b6ab340");
                 done();
             });
         });
@@ -58,7 +76,8 @@ describe("Cached", function() {
     describe(".toFile/.fromFile", function() {
 
         before(function() {
-            cached.cache = {};
+            cache = Cached({ cacheFile: CACHE_FILE });
+            cached = cache.cached; // Extract reference to cached
         });
 
         it("should write the cache to a file.", function() {

--- a/test/index.js
+++ b/test/index.js
@@ -177,19 +177,19 @@ describe("Cached", function() {
         }
     });
 
-    describe("onexit", function() {
+    describe("onfinish", function() {
         var tempCache = __dirname + "/cache-temp.json";
 
         it("should save the cache file on changes", function() {
             cached.changes = true;
             cached.options.cacheFile = tempCache
-            cached.onexit();
+            cached.onfinish();
             assert(fs.existsSync(tempCache));
         });
 
         it("should not throw an error if the cache directory does not exist", function() {
             cached.options.cacheFile = __dirname + "unknown-dir/FOO-BOO";
-            cached.onexit();
+            cached.onfinish();
         });
 
         after(function(done) {


### PR DESCRIPTION
Needed the ability to create multiple file caches in the same gulp execution, e.g.

``` javascript
const cacheTranspile = cacheMoney({cacheFile: path.join(__dirname, '.gulp-cache-transpile')});
const cacheScss = cacheMoney({cacheFile: path.join(__dirname, '.gulp-cache-scss')});

gulp.task('transpile', () => 
  gulp.src('src/**/*.js')
  .pipe(cacheTranspile())
  .pipe(babel())
  .pipe(gulp.dest('build'));
);

gulp.task('scss', () => 
  gulp.src('src/**/*.scss')
  .pipe(cacheScss())
  .pipe(scss())
  .pipe(gulp.dest('build'));
);

gulp.task('default', ['transpile', 'scss']);
```
